### PR TITLE
Don't pin release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
 		"Typing :: Typed",
 	],
 	install_requires=[
-		'aiohttp==3.7.4',
+		'aiohttp>=3.7.4,<4',
 	],
 	python_requires='>=3.6',
 )


### PR DESCRIPTION
This avoids that users get affected by CVE-2021-21330.